### PR TITLE
Add drop-down boxes for advanced options

### DIFF
--- a/castawesome.py
+++ b/castawesome.py
@@ -327,9 +327,6 @@ class Settings:
 		self.builder.get_object("entry_fps").set_text(self.fps)
 		self.builder.get_object("entry_bitrate").set_text(self.bitrate)
 		self.builder.get_object("entry_audio_bitrate").set_text(self.audio_bitrate)
-		self.builder.get_object("entry_video_container").set_text(self.video_container)
-		self.builder.get_object("entry_video_codec").set_text(self.video_codec)
-		self.builder.get_object("entry_audio_codec").set_text(self.audio_codec)
 		self.builder.get_object("entry_threads").set_text(self.threads)
 		
 		# Set the capture_region switch to the correct state
@@ -374,10 +371,27 @@ class Settings:
 		for otheritem in presets:
 			self.builder.get_object("list_presets").append(otheritem)
 		
+		# Append advanced options to GTK's liststores
+		for key in ["video_container", "video_codec", "audio_codec"]:
+			lst = self.builder.get_object("list_" + key)
+			val = getattr(self, "get_" + key)()
+			idx = 0
+			for item in self.advanced_options[key]:
+				name = item["name"]
+				lst.append([name])
+				if name == val:
+					self.builder.get_object("combo_" + key).set_active(idx)
+				idx += 1
+		
 		# Stupid hack for GTK's weirdness
-		cell = Gtk.CellRendererText()
-		self.builder.get_object("combo_preset_selector").pack_start(cell, True)
-		self.builder.get_object("combo_preset_selector").add_attribute(cell, 'text', 0)
+		for obj in [
+				"combo_preset_selector",
+				"combo_video_container",
+				"combo_video_codec",
+				"combo_audio_codec"]:
+			cell = Gtk.CellRendererText()
+			self.builder.get_object(obj).pack_start(cell, True)
+			self.builder.get_object(obj).add_attribute(cell, 'text', 0)
 		
 		# Set the service selector based on the loaded configs
 		if self.service == 'rtmp://live.twitch.tv/app/':
@@ -536,6 +550,13 @@ class Settings:
 			self.builder.get_object("box_advanced").hide()
 		print self.advanced
 	
+	def on_advanced_option_changed(self, widget):
+		key = Gtk.Buildable.get_name(widget)[len("combo_"):]
+		active = widget.get_active()
+		if active >= 0:
+			setattr(self, key, widget.get_model()[active][0])
+		print "{0}: {1}".format(key, getattr(self, "get_" + key)())
+	
 	def on_button_apply_clicked(self, window):
 		self.inres = self.builder.get_object("entry_inres").get_text()
 		self.outres = self.builder.get_object("entry_outres").get_text()
@@ -544,9 +565,6 @@ class Settings:
 		self.fps = self.builder.get_object("entry_fps").get_text()
 		self.bitrate = self.builder.get_object("entry_bitrate").get_text()
 		self.audio_bitrate = self.builder.get_object("entry_audio_bitrate").get_text()
-		self.video_container = self.builder.get_object("entry_video_container").get_text()
-		self.video_codec = self.builder.get_object("entry_video_codec").get_text()
-		self.audio_codec = self.builder.get_object("entry_audio_codec").get_text()
 		self.threads = self.builder.get_object("entry_threads").get_text()
 
 		# Save configs in homefolder

--- a/castawesome.py
+++ b/castawesome.py
@@ -151,7 +151,7 @@ class GUI:
 		Gtk.main_quit()
 
 def get_advanced_options():
-	options = {"containers": [], "video": [], "audio": []}
+	options = {"video_container": [], "video_codec": [], "audio_codec": []}
 
 	# make avconv list containers (which it calls formats)
 	for line in subprocess.check_output(["avconv", "-formats"]).splitlines():
@@ -165,7 +165,7 @@ def get_advanced_options():
 		if match:
 			props, name, desc = match.group(1, 2, 3)
 			if 'E' in props: # only formats that we can actually encode
-				options["containers"].append({"name": name, "desc": desc})
+				options["video_container"].append({"name": name, "desc": desc})
 
 	# make avconv list decoders
 	for line in subprocess.check_output(["avconv", "-decoders"]).splitlines():
@@ -180,9 +180,9 @@ def get_advanced_options():
 			props, name, desc = match.group(1, 2, 3)
 			decoder = {"name": name, "desc": desc}
 			if 'V' in props: # video codec
-				options["video"].append(decoder)
+				options["video_codec"].append(decoder)
 			if 'A' in props: # audio codec
-				options["audio"].append(decoder)
+				options["audio_codec"].append(decoder)
 
 	return options
 

--- a/castawesome_settings.ui
+++ b/castawesome_settings.ui
@@ -24,6 +24,21 @@
       <column type="gchararray"/>
     </columns>
   </object>
+  <object class="GtkListStore" id="list_video_container">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="list_video_codec">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="list_audio_codec">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkToggleAction" id="toggle_advanced">
     <signal name="toggled" handler="on_toggle_advanced_toggled" swapped="no"/>
   </object>
@@ -467,9 +482,14 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry" id="entry_video_container">
+                  <object class="GtkComboBox" id="combo_video_container">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">list_video_container</property>
+                    <property name="column_span_column">0</property>
+                    <property name="active">1</property>
+                    <property name="button_sensitivity">on</property>
+                    <signal name="changed" handler="on_advanced_option_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -502,9 +522,14 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry" id="entry_video_codec">
+                  <object class="GtkComboBox" id="combo_video_codec">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">list_video_codec</property>
+                    <property name="column_span_column">0</property>
+                    <property name="active">1</property>
+                    <property name="button_sensitivity">on</property>
+                    <signal name="changed" handler="on_advanced_option_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -537,9 +562,14 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry" id="entry_audio_codec">
+                  <object class="GtkComboBox" id="combo_audio_codec">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">list_audio_codec</property>
+                    <property name="column_span_column">0</property>
+                    <property name="active">1</property>
+                    <property name="button_sensitivity">on</property>
+                    <signal name="changed" handler="on_advanced_option_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
I had some trouble with Chrome users seeing only blackness when using Picarto.tv and the regular `flv` video codec. It was solved simply by using a different codec, but it was annoying to have to keep switching between a terminal listing all the codecs that avconv knows and then back to Castawesome to type it in.

This patch adds drop-down boxes instead of text entry fields, whose options are parsed from `avconv -formats` and `avconv -decoders`. That way a user doesn't have to enter them manually anymore.
